### PR TITLE
return QString::Null instead of empty string for missing tags

### DIFF
--- a/simplexmlparser_class/SimpleXmlParser.cpp
+++ b/simplexmlparser_class/SimpleXmlParser.cpp
@@ -139,8 +139,8 @@ SimpleXmlParser::findStartTagDelimiters(const QString &i_msg, const QString &i_t
   \param i_msg the message to parse
   \param i_tag the tag we want to find and parse
   \param i_offset the initial offset we should start looking the tag from, its default is 0
-  \return the string contained within the found tag
-  \note we assume the tag ALWAYS exists
+  \param defaultValue the value returned if the tag is not found
+  \return the string contained within the found tag or defaultValue if the tag is not found
   */
 QString
 SimpleXmlParser::getTagValue(const QString & i_msg, const QString & i_tag, int i_offset, QString defaultValue)

--- a/simplexmlparser_class/SimpleXmlParser.h
+++ b/simplexmlparser_class/SimpleXmlParser.h
@@ -48,8 +48,8 @@ public:
     void emptyBuffer();
     QString getCurrentBuffer() const;
 
-    static QString      getTagValue          (const QString &msg, const QString &tag, int beginidx=0, QString defaultValue="");
-    static QString      getDecodedTagValue   (const QString &msg, const QString &tag, int beginidx=0, QString defaultValue="");
+    static QString      getTagValue          (const QString &msg, const QString &tag, int beginidx=0, QString defaultValue=QString());
+    static QString      getDecodedTagValue   (const QString &msg, const QString &tag, int beginidx=0, QString defaultValue=QString());
 
     static QStringList  getTagsValues        (const QString &msg, const QString &tag);
     static QStringList  getDecodedTagsValues (const QString &msg, const QString &tag);


### PR DESCRIPTION
This allows to distinguish empty tags that returns an empty string
from missing tags that would return Null QStrings.
This change is retrocompatible: using QString::isEmpty() on the result
will return true even on Null QStrings.